### PR TITLE
Allow robo to run individual .feature tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,19 +137,11 @@ $ tests/vendor/bin/robo run:tests
 
 #### You can individual run `feature` using following command.
 
-To run `content` feature use,
-
 ```bash
-$ tests/vendor/bin/codecept run tests/acceptance/content.feature
+$ tests/vendor/bin/robo run:test
 ```
 
-To run `users` feature use,
-
-```bash
-$ tests/vendor/bin/codecept run tests/acceptance/users.feature
-```
-
-_If you want to see steps then you can use `--steps` option of codeceptio. Check [full codecept command list here](http://codeception.com/docs/reference/Commands#Run)_
+_If you want to see steps then you can use `--steps` option of codeception. Check [full codecept command list here](http://codeception.com/docs/reference/Commands#Run)_
 
 **Note**:You can modify the timeout time by setting the value of **TIMEOUT** constant lower for fast machines and higher for slow computers. The constant located in the file `tests/acceptance/_bootstrap.php`
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,13 @@ $ tests/vendor/bin/robo run:tests
 $ tests/vendor/bin/robo run:test
 ```
 
-_If you want to see steps then you can use `--steps` option of codeception. Check [full codecept command list here](http://codeception.com/docs/reference/Commands#Run)_
+Or you can manually run them using codecept command. Check the following example:
+
+```bash
+$ tests/vendor/bin/codecept run tests/acceptance/users.feature
+```
+
+If you want to see steps then you can use `--steps` option of codeception. Check [full codecept command list here](http://codeception.com/docs/reference/Commands#Run)_
 
 **Note**:You can modify the timeout time by setting the value of **TIMEOUT** constant lower for fast machines and higher for slow computers. The constant located in the file `tests/acceptance/_bootstrap.php`
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -365,7 +365,9 @@ class RoboFile extends \Robo\Tasks
 			while ($iterator->valid())
 			{
 				if (strripos($iterator->getSubPathName(), 'cept.php')
-					|| strripos($iterator->getSubPathName(), 'cest.php'))
+					|| strripos($iterator->getSubPathName(), 'cest.php')
+					|| strripos($iterator->getSubPathName(), '.feature'))
+
 				{
 					$this->say('[' . $i . '] ' . $iterator->getSubPathName());
 					$tests[$i] = $iterator->getSubPathName();
@@ -383,21 +385,23 @@ class RoboFile extends \Robo\Tasks
 		$pathToTestFile = 'tests/' . $suite . '/' . $test;
 
 		//loading the class to display the methods in the class
-		require 'tests/' . $suite . '/' . $test;
 
 		//logic to fetch the class name from the file name
 		$fileName = explode("/", $test);
-		$className = explode(".", $fileName[1]);
 
-		//if the selected file is cest only than we will give the option to execute individual methods, we don't need this in cept file
+		// If the selected file is cest only then we will give the option to execute individual methods, we don't need this in cept or feature files
 		$i = 1;
 
-		if (strripos($className[0], 'cest'))
+		if (isset($fileName[1]) && strripos($fileName[1], 'cest'))
 		{
+			require 'tests/' . $suite . '/' . $test;
+
+			$className = explode(".", $fileName[1]);
 			$class_methods = get_class_methods($className[0]);
 			$this->say('[' . $i . '] ' . 'All');
 			$methods[$i] = 'All';
 			$i++;
+
 			foreach ($class_methods as $method_name)
 			{
 				$reflect = new ReflectionMethod($className[0], $method_name);


### PR DESCRIPTION
#### Summary of Changes

This pull requests adds to Robo the possibility of running `.feature` file tests. Before we were able to run `Cest` and `Cept` test files.
#### Testing Instructions

To test it try running any of the .feature available files by typing:

`tests/vendor/bin/robo run:test`

You should get a list of  available tests, and you should be able to run one.
