### PR TITLE
correction changing tab when testing add user

### DIFF
--- a/tests/codeception/_support/Step/Acceptance/Administrator/User.php
+++ b/tests/codeception/_support/Step/Acceptance/Administrator/User.php
@@ -40,6 +40,7 @@ class User extends Admin
 
 		$I->amOnPage(UserManagerPage::$url);
 		$I->adminPage->clickToolbarButton('New');
+                $I->click('Account Details');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

In the feature Scenario: "Edit User" we changed the tab of the user edit page. That is why this tab is active when we use it in the Scenario: "Create super admin and login into the backend" and in the Scenario: "Create User without username fails". 

Adding $I->click('Account Details') to the function iAssignedNameAndUserGroup, ensures that the first tab is active, when we use "Given There is a add user link".

Perhaps we should put this text into a page, but in this case we should do this with the text 
$I->click('Assigned User Groups');
at line 353 of the file user.php, too.


