### PR TITLE
Add a scroll to a element out of fold

### DIFF
--- a/tests/codeception/_support/Page/Acceptance/Administrator/ArticleManagerPage.php
+++ b/tests/codeception/_support/Page/Acceptance/Administrator/ArticleManagerPage.php
@@ -91,7 +91,7 @@ class ArticleManagerPage extends AdminPage
 		$I = $this;
 
 		$I->fillField(self::$title, $title);
-
+                $I->scrollTo(['css'=> 'div.toggle-editor']);
 		$I->click(self::$toggleEditor);
 		$I->fillField(self::$content, $content);
 	}


### PR DESCRIPTION
Pull Request for Issue # 
No issue

### Summary of Changes
Insert a line to scroll to an element, that we want to use, but that is below the fold

### Testing Instructions

### Documentation Changes Required

