### PR TITLE
Better wrapper method to display search tools

### DIFF
--- a/tests/codeception/_support/Page/Acceptance/Administrator/AdminPage.php
+++ b/tests/codeception/_support/Page/Acceptance/Administrator/AdminPage.php
@@ -370,4 +370,32 @@ class AdminPage extends \AcceptanceTester
 		$I->waitForPageTitle($pageTitle);
 		$I->see($item, static::$seeName);
 	}
+        
+        /**
+         * Assure the search tools are displayed
+         * 
+         * @since   __DEPLOY_VERSION__
+         *  
+         * @return  void
+         */
+        public function displaySearchTools()
+        {
+            $I = $this;
+            
+            try {
+                $I->seeElement(['class' => 'js-stools-btn-filter']);
+            } catch (Exception $e) {
+                $I->comment("Search tools button does not exist on this page, skipping");
+                return;
+            }
+}
+            try {
+                $I->dontSeeElement(['class' => 'js-stools-container-filters']);
+            } catch (Exception $e) {
+                $I->comment("Search tools already visible on the page, skipping");
+                return;
+            }
+                
+            $I->click('Search Tools');
+        }
 }


### PR DESCRIPTION
Pull Request for Issue #: no issue. 

### Original issue
The search tools in any administrator manager page are only displayed when you click on "Search tools". Up until now, in all our tests, when we had to show the search tools we just used:

    $I->click('Search tools')

but this does not consider that the search tools may be already displayed from a previous command, in which case clicking again on the button actually **hides** the search tools.

### Summary of Changes
I created a new method in the **adminPage** object which can be used like this:

    $I->displaySearchTools();

The method does all required checks to make sure we get the desired result.

### Testing Instructions
Create a test where you use

    $i->click('Search tools') 

twice in a row. You will see that the search tools are hidden. Now, create another test were you use

    $I->displaySearchTools();

twice, and search tools should be displayed.

### Documentation Changes Required
None that I am aware of.
