### PR TITLE
Fix in the RoboFile in the env parameter

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -331,7 +331,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/install/')
 			->run()
 			->stopOnFail();
@@ -340,7 +340,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/content.feature')
 			->run()
 			->stopOnFail();
@@ -349,7 +349,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/users.feature')
 			->run()
 			->stopOnFail();
@@ -358,7 +358,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/users_frontend.feature')
 			->run()
 			->stopOnFail();
@@ -367,7 +367,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/banner.feature')
 			->run()
 			->stopOnFail();
@@ -376,7 +376,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/extensions.feature')
 			->run()
 			->stopOnFail();
@@ -385,7 +385,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/category.feature')
 			->run()
 			->stopOnFail();
@@ -394,7 +394,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/administrator/')
 			->run()
 			->stopOnFail();
@@ -403,7 +403,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
-			->arg('--env ' . $opts['env'])
+			->env($opts['env'])
 			->arg($this->testsPath . 'acceptance/frontend/')
 			->run()
 			->stopOnFail();


### PR DESCRIPTION
### Summary of Changes
Fixing a bug with newest Robo version

Changed
->arg('--env ' . $opts['env'])
to
->env($opts['env'])

### Testing Instructions
Confirm that robo run:tests is working

### Documentation Changes Required
None