### PR TITLE
creating custom fields

### DIFF
--- a/tests/codeception/_support/Page/Acceptance/Administrator/FieldGroupsManagerPage.php
+++ b/tests/codeception/_support/Page/Acceptance/Administrator/FieldGroupsManagerPage.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Page
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Page\Acceptance\Administrator;
+
+/**
+ * Acceptance Page object class to define Fields Manager page objects.
+ *
+ * @package  Page\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class FieldGroupsManagerPage extends AdminPage
+{
+	/**
+	 * Link to the article listing page.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $url = "/administrator/index.php?option=com_fields&view=groups&context=com_content.article";
+}

--- a/tests/codeception/_support/Page/Acceptance/Administrator/FieldGroupsManagerPage_New.php
+++ b/tests/codeception/_support/Page/Acceptance/Administrator/FieldGroupsManagerPage_New.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Page
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Page\Acceptance\Administrator;
+
+/**
+ * Acceptance Page object class to define Fields Manager page objects.
+ *
+ * @package  Page\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class FieldGroupsManagerPage_New extends AdminPage
+{
+	/**
+	 * Link to the article listing page.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $url = "/administrator/index.php?option=com_fields&view=group&layout=edit";
+}

--- a/tests/codeception/_support/Page/Acceptance/Administrator/FieldsManagerPage.php
+++ b/tests/codeception/_support/Page/Acceptance/Administrator/FieldsManagerPage.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Page
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Page\Acceptance\Administrator;
+
+/**
+ * Acceptance Page object class to define Fields Manager page objects.
+ *
+ * @package  Page\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class FieldsManagerPage extends AdminPage
+{
+	public static $url = "/administrator/index.php?option=com_fields&context=com_content.article";
+}

--- a/tests/codeception/_support/Page/Acceptance/Administrator/FieldsManagerPage_New.php
+++ b/tests/codeception/_support/Page/Acceptance/Administrator/FieldsManagerPage_New.php
@@ -1,0 +1,423 @@
+<?php
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Page
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Page\Acceptance\Administrator;
+
+/**
+ * Acceptance Page object class to define Fields Manager page objects.
+ *
+ * @package  Page\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class FieldsManagerPage_New extends AdminPage
+{
+	/**
+	 * Locator for field placeholder
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $placeholder = ['id' => 'jform_params_hint'];
+
+	/**
+	 * Locator for field render class
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $render_class = ['id' => 'jform_params_render_class'];
+
+	/**
+	 * Locator for field render class
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $renderclass = ['id' => 'jform_params_render_class'];
+
+	/**
+	 * Locator for field edit class
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $editclass = ['id' => 'jform_params_class'];
+
+	/**
+	 * Locator for field disabled
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $disabled = ['id' => 'jform_params_disabled'];
+
+	/**
+	 * Locator for field show on
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $showon = ['id' => 'jform_params_show_on'];
+
+	/**
+	 * Locator for field automatic display
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $display = ['id' => 'jform_params_display'];
+
+	/**
+	 * Locator for field read only
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $readonly = ['id' => 'jform_params_readonly'];
+
+	/**
+	 * Locator the register general
+	 *
+	 * @var    text
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $general = "General";
+
+	/**
+	 * Locator the register options
+	 *
+	 * @var    text
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $options = "Options";
+
+	/**
+	 * Name of the text to identify the page.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $pageTitleText = 'Articles: Edit Field';
+
+	/**
+	 * Locator for field label
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $label = ['id' => 'jform_label'];
+
+	/**
+	 * Locator for field unique_name
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $unique_name = ['id' => 'jform_unique_name'];
+
+	/**
+	 * Locator for field description
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $description = ['id' => 'jform_description'];
+
+	/**
+	 * Link to the article listing page.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $url = "/administrator/index.php?option=com_fields&view=field&layout=edit&context=com_content.article";
+
+	/**
+	 * Locator for field type
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $type = ['id' => 'jform_type'];
+
+	/**
+	 * Locator for field type
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $access = ['id' => 'jform_access'];
+
+	/**
+	 * Locator for field type
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $language = ['id' => 'jform_language'];
+
+	/**
+	 * Locator for field type
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $note = ['id' => 'jform_note'];
+
+	/**
+	 * Locator for field default_value
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $default_value = ['id' => 'jform_default_value'];
+
+	/**
+	 * Locator for field fieldparams_showtime
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $showtime = ['id' => 'jform_fieldparams_showtime'];
+
+	/**
+	 * Locator for field required
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $required = ['id' => 'jform_required'];
+
+	/**
+	 * Locator for field state
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $state = ['id' => 'jform_state'];
+
+	/**
+	 * Locator for field jform_cat_ids
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $cat_ids = ['id' => 'jform_assigned_cat_ids_chzn'];
+
+	/**
+	 * Locator for field jform_groupid
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $groupid = ['id' => 'jform_group_id'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_button
+	 * Attention this is for insert values into checkbox fields
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $options_button = ['id' => 'jform_fieldparams_options_button'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_button
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $thumbnail_width = ['id' => 'jform_fieldparams_thumbnail_width'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_max_width
+	 * Max width of the gallery field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $max_width = ['id' => 'jform_fieldparams_max_width'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_max_height
+	 * Max height of the gallery field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $max_height = ['id' => 'jform_fieldparams_max_height'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_recursive
+	 * Recursive in gallery field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $recursive = ['id' => 'jform_fieldparams_recursive'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_multiple
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $multiple = ['id' => 'jform_fieldparams_multiple'];
+
+	/**
+	 * Locator for field filter
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $filter = ['id' => 'jform_fieldparams_filter'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_directory
+	 * Directory of the gallery and image field (text) and the image field (select)
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $directory = ['id' => 'jform_fieldparams_directory'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_buttons
+	 * Attention this is for hide buttons in edit field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $buttons = ['id' => 'jform_fieldparams_buttons'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_hide
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $hide = ['id' => 'jform_fieldparams_hide'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_width
+	 * Width of the edit field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $width = ['id' => 'jform_fieldparams_width'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_height
+	 * Height of the editor field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $height = ['id' => 'jform_fieldparams_height'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_rows
+	 * Rows of the editor field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $rows = ['id' => 'jform_fieldparams_rows'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_cols
+	 * columns of the editor field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $cols = ['id' => 'jform_fieldparams_cols'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_image_class
+	 * image_class of the image field, media field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $image_class = ['id' => 'jform_fieldparams_image_class'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_first
+	 * columns of the integer field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $first = ['id' => 'jform_fieldparams_first'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_last
+	 * columns of the integer field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $last = ['id' => 'jform_fieldparams_last'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_step
+	 * columns of the integer field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $step = ['id' => 'jform_fieldparams_step'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_preview
+	 * preview of the media field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $preview = ['id' => 'jform_fieldparams_preview'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_home
+	 * home of the media field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $home = ['id' => 'jform_fieldparams_home'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_query
+	 * query of the sql field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $query = ['id' => 'jform_fieldparams_query'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_schemes
+	 * schemes of the url field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $schemes = ['id' => 'jform_fieldparams_schemes_chzn'];
+
+	/**
+	 * Locator for field jform_fieldparams_options_relative
+	 * relative of the url field
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $relative = ['id' => 'jform_fieldparams_relative'];
+}

--- a/tests/codeception/_support/Step/Acceptance/Administrator/Admin.php
+++ b/tests/codeception/_support/Step/Acceptance/Administrator/Admin.php
@@ -18,6 +18,10 @@ use Page\Acceptance\Administrator\MenuManagerPage;
 use Page\Acceptance\Administrator\UserAclPage;
 use Page\Acceptance\Administrator\UserGroupPage;
 use Page\Acceptance\Administrator\UserManagerPage;
+use Page\Acceptance\Administrator\FieldGroupsManagerPage_New;
+use Page\Acceptance\Administrator\FieldGroupsManagerPage;
+use Page\Acceptance\Administrator\FieldsManagerPage_New;
+use Page\Acceptance\Administrator\FieldsManagerPage;
 
 /**
  * Acceptance Step object class for admin steps.
@@ -111,6 +115,10 @@ class Admin extends \AcceptanceTester
 		$this->userAclPage         = new UserAclPage($scenario);
 		$this->menuManagerPage     = new MenuManagerPage($scenario);
 		$this->extensionManagerPage = new ExtensionManagerPage($scenario);
+		$this->fieldgroupsManagerPage = new ExtensionManagerPage($scenario);
+		$this->fieldsManagerPage = new FieldsManagerPage($scenario);
+		$this->fieldgroupsManagerPage_New = new FieldgroupsManagerPage_New($scenario);
+		$this->fieldsManagerPage_New = new FieldsManagerPage_New($scenario);
 	}
 
 	/**
@@ -130,5 +138,22 @@ class Admin extends \AcceptanceTester
 
 		$I->waitForText($message, TIMEOUT, AdminPage::$systemMessageContainer);
 		$I->see($message, AdminPage::$systemMessageContainer);
+	}
+
+	/**
+	 * Function to select Toolbar buttons in Joomla! Admin Toolbar Panel
+	 *
+	 * @param   string  $button  The full name of the button
+	 *
+	 * @Given I click toolbar button :arg1
+	 * 
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iclickToolbarButton($button)
+	{
+		$I = $this;
+		$I->adminPage->clickToolbarButton($button);
 	}
 }

--- a/tests/codeception/_support/Step/Acceptance/Administrator/FieldGroups.php
+++ b/tests/codeception/_support/Step/Acceptance/Administrator/FieldGroups.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Step
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Step\Acceptance\Administrator;
+
+use Page\Acceptance\Administrator\FieldGroupsManagerPage;
+use Page\Acceptance\Administrator\FieldGroupsManagerPage_New;
+
+/**
+ * Acceptance Step object class contains suits for Content Manager.
+ *
+ * @package  Step\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class FieldGroups extends Admin
+{
+	/**
+	 * Method to click toolbar button new from article manager listing page.
+	 *
+	 * @Given There is a add field group link
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function thereIsAAddFieldGroupLink()
+	{
+		$I = $this;
+
+		$I->amOnPage(FieldGroupsManagerPage::$url);
+	}
+
+	/**
+	 * Method to create new field group
+	 *
+	 * @param   string  $group_titles  The field group title
+	 *
+	 * @When I fill mandatory fields for creating Field Group
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillMandatoryFieldsForCreatingFieldGroup($group_titles)
+	{
+		$I = $this;
+
+		$I->adminPage->clickToolbarButton('New');
+
+		$totalRows = count($group_titles->getRows());
+		$lastIndex = ($totalRows - 1);
+
+		// Iterate over all rows
+		foreach ($group_titles->getRows() as $index => $row)
+		{
+			if ($index !== 0)
+			{
+				$I->fillField(FieldGroupsManagerPage_New::$title, $row[0]);
+
+				if ($index == $lastIndex)
+				{
+					$I->adminPage->clickToolbarButton('Save');
+					$I->wait(5);
+				}
+				else
+				{
+					$I->adminPage->clickToolbarButton('Save & New');
+				}
+			}
+		}
+	}
+}

--- a/tests/codeception/_support/Step/Acceptance/Administrator/Fields.php
+++ b/tests/codeception/_support/Step/Acceptance/Administrator/Fields.php
@@ -1,0 +1,1470 @@
+<?php
+
+/**
+ * @package     Joomla.Test
+ * @subpackage  AcceptanceTester.Step
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Step\Acceptance\Administrator;
+
+use Page\Acceptance\Administrator\FieldsManagerPage;
+use Page\Acceptance\Administrator\FieldsManagerPage_New;
+use Page\Acceptance\Administrator\ArticleManagerPage;
+use Page\Acceptance\Site\FrontPage;
+
+/**
+ * Acceptance Step object class contains suits for Content Manager.
+ *
+ * @package  Step\Acceptance\Administrator
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class Fields extends Admin
+{
+	/**
+	 * Method to click toolbar button new from article manager listing page.
+	 *
+	 * @Given There is a add field link
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function thereIsAAddFieldLink()
+	{
+		$I = $this;
+
+		$I->amOnPage(FieldsManagerPage::$url);
+	}
+
+	/**
+	 * Method to fill the title field
+	 *
+	 * @param   string  $title  The field title
+	 *
+	 * @Given I fill field title with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldTitleWith($title)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$title, $title);
+	}
+
+	/**
+	 * Method to fill the type field
+	 *
+	 * @param   string  $type  The field type
+	 *
+	 * @Given I select field type :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldType($type)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$type['id'], $type);
+	}
+
+	/**
+	 * Method to fill the label field
+	 *
+	 * @param   string  $label  The field label
+	 *
+	 * @Given I fill field label  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldLabelWith($label)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$label, $label);
+	}
+
+	/**
+	 * Method to fill the description field
+	 *
+	 * @param   string  $description  The field description
+	 *
+	 * @Given I fill field description  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldDescriptionWith($description)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$description, $description);
+	}
+
+	/**
+	 * Method to fill the required field
+	 *
+	 * @param   string  $arg  The field required
+	 *
+	 * @Given I check option required :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionRequired($arg)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->click("//fieldset[@id='" . FieldsManagerPage_New::$required['id'] . "']/label[contains(normalize-space(string(.)), '" . $arg . "')]");
+	}
+
+	/**
+	 * Method to fill the default value field
+	 *
+	 * @param   string  $default_value  The field default value
+	 *
+	 * @Given I fill field default_value  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldDefault_valueWith($default_value)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$default_value, $default_value);
+	}
+
+	/**
+	 * Method to fill the state field
+	 *
+	 * @param   string  $state  The field state
+	 *
+	 * @Given I select field state :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldState($state)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$state['id'], $state);
+	}
+
+	/**
+	 * Method to fill the field group field
+	 *
+	 * @param   string  $groupid  The field field group
+	 *
+	 * @Given I select field group :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldGroup($groupid)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$groupid['id'], $groupid);
+	}
+
+	/**
+	 * Method to select a category in the categories field
+	 *
+	 * @param   string  $cat_ids  The categories
+	 *
+	 * @Given I select field cat :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldCat($cat_ids)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->click('#' . FieldsManagerPage_New::$cat_ids['id']);
+		$I->click("//div[@id='" . FieldsManagerPage_New::$cat_ids['id'] .
+				"']/div/ul/li[contains(normalize-space(string(.)), '" . $cat_ids . "')]");
+	}
+
+	/**
+	 * Method to unselect a category in the categories field
+	 *
+	 * @param   string  $cat_ids  The categrories
+	 *
+	 * @Given I unselect field cat :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iUnselectFieldCats($cat_ids)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->click("//div[@id='" . FieldsManagerPage_New::$cat_ids['id'] .
+				"']/ul/li/span[contains(normalize-space(string(.)), '" . $cat_ids .
+				"')]/following-sibling::a[1]");
+	}
+
+	/**
+	 * Method to fill the access field
+	 *
+	 * @param   string  $access  The access
+	 *
+	 * @Given I select field access :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldAccess($access)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo(['css' => '#' . FieldsManagerPage_New::$access['id']], 20, 100);
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$access['id'], $access);
+	}
+
+	/**
+	 * Method to fill the language field
+	 *
+	 * @param   string  $language  The language
+	 *
+	 * @Given I select field language :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldLanguage($language)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo(['css' => '#' . FieldsManagerPage_New::$language['id']], 20, 100);
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$language['id'], $language);
+	}
+
+	/**
+	 * Method to fill the note field
+	 *
+	 * @param   string  $note  The note
+	 *
+	 * @Given I fill field note with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldNoteWith($note)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo(['css' => '#' . FieldsManagerPage_New::$note['id']], 20, 100);
+		$I->fillField(FieldsManagerPage_New::$note, $note);
+	}
+
+	/**
+	 * Method to fill the show time field for cumstom field calendar
+	 *
+	 * @param   string  $arg  The field show time
+	 *
+	 * @Given I check option showtime :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionShowtime($arg)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->click("//fieldset[@id='" . FieldsManagerPage_New::$showtime['id'] . "']/label[contains(normalize-space(string(.)), '" . $arg . "')]");
+	}
+
+	/**
+	 * Method to fill the options field for custom field list, checkbox and radio
+	 *
+	 * @param   string  $names_values  The options
+	 *
+	 * @Given I fill field options
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldOptions($names_values)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo(['css' => '.adminlist'], 20, 50);
+
+		$totalRows = count($names_values->getRows());
+		$lastIndex = ($totalRows - 1);
+
+		$I->click('.group-add');
+
+		foreach ($names_values->getRows() as $index => $row)
+		{
+			if ($index !== 0)
+			{
+				$I->fillField('#jform_fieldparams_options_options' . $index . '_name', $row[0]);
+				$I->fillField('#jform_fieldparams_options_options' . $index . '_value', $row[1]);
+
+				if ($index == $lastIndex)
+				{
+					// We do not have to do a click on save any more $I->click('.save-modal-data');
+				}
+				else
+				{
+					$I->click('.group-add');
+				}
+			}
+		}
+	}
+
+	/**
+	 * Method to fill the thumbnailswidth field for custom field gallery
+	 *
+	 * @param   string  $thumb  The thumbnailwidth
+	 *
+	 * @Given I fill field ThumbnailWidth  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldThumbnailWidthWith($thumb)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$thumbnail_width, $thumb);
+	}
+
+	/**
+	 * Method to fill the maxwidth field for custom field gallery
+	 *
+	 * @param   string  $maxwidth  The maxwidth
+	 *
+	 * @Given I fill field MaxWidth  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldMaxWidthWith($maxwidth)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$max_width, $maxwidth);
+	}
+
+	/**
+	 * Method to fill the maxheight field for custom field gallery
+	 *
+	 * @param   string  $maxheight  The maxheigth
+	 *
+	 * @Given I fill field MaxHeight  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldMaxHeightWith($maxheight)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$max_height, $maxheight);
+	}
+
+	/**
+	 * Method to fill the recursive field for custom field gallery
+	 *
+	 * @param   string  $arg  The recursive
+	 *
+	 * @Given I check option recursive :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionRecursive($arg)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo("//select[@id='" . FieldsManagerPage_New::$recursive['id'] . "']");
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$recursive['id'], $arg);
+	}
+
+	/**
+	 * Method to fill the multiple field for custom field gallery, image, integer, list, sql, userfield and usergroup
+	 *
+	 * @param   string  $arg  The multiple
+	 *
+	 * @Given I check option multiple :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionMultiple($arg)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo("//select[@id='" . FieldsManagerPage_New::$multiple['id'] . "']", 20, 200);
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$multiple['id'], $arg);
+	}
+
+	/**
+	 * Method to fill the directory field for custom field gallery and media
+	 * Attention: In image field directory is a select field -> use iSelectFieldDirectoryWith
+	 *
+	 * @param   string  $directory  The directory
+	 *
+	 * @Given I fill field directory  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldDirectoryWith($directory)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$directory, $directory);
+	}
+
+	/**
+	 * Method to click field for hiding buttons in editor field
+	 *
+	 * @param   string  $arg  The arg (yes or no)
+	 *
+	 * @Given I check option buttons :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionButtons($arg)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$buttons['id'], $arg);
+	}
+
+	/**
+	 * Method to fill the hide field for custom field editor
+	 *
+	 * @param   string  $hide  The fields to hide
+	 *
+	 * @Given I fill field hide  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldHideWith($hide)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$hide, $hide);
+	}
+
+	/**
+	 * Method to fill the width field for custom field editor
+	 *
+	 * @param   string  $width  The width
+	 *
+	 * @Given I fill field width  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldWidthWith($width)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$width, $width);
+	}
+
+	/**
+	 * Method to fill the height field for custom field editor
+	 *
+	 * @param   string  $height  The height
+	 *
+	 * @Given I fill field height  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldHeightWith($height)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$height, $height);
+	}
+
+	/**
+	 * Method to fill the filter field
+	 *
+	 * @param   string  $filter  The field filter
+	 *
+	 * @Given I select field filter :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldFilter($filter)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo("//select[@id='" . FieldsManagerPage_New::$filter['id'] . "']", 10, 100);
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$filter['id'], $filter);
+	}
+
+	/**
+	 * Method to fill the row field for custom field editor and textare
+	 *
+	 * @param   string  $rows  The rows
+	 *
+	 * @Given I fill field rows  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldRowsWith($rows)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$rows, $rows);
+	}
+
+	/**
+	 * Method to fill the columns field for custom field editor and textarea
+	 *
+	 * @param   string  $cols  The columns
+	 *
+	 * @Given I fill field cols  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldColsWith($cols)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$cols, $cols);
+	}
+
+	/**
+	 * Method to fill the directory field for custom field image
+	 * Attention: In gallery and media field directory is a text field -> use iFillFieldDirectoryWith
+	 *
+	 * @param   string  $directory  The directory
+	 *
+	 * @Given I select field directory  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldDirectoryWith($directory)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$directory['id'], $directory);
+	}
+
+	/**
+	 * Method to fill the image_class field for custom field image
+	 *
+	 * @param   string  $image_class  The image_class
+	 *
+	 * @Given I fill field image_class  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldImage_classWith($image_class)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$image_class, $image_class);
+	}
+
+	/**
+	 * Method to fill the first field for custom field integer
+	 *
+	 * @param   string  $first  The first value
+	 *
+	 * @Given I fill field first  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldFirstWith($first)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$first, $first);
+	}
+
+	/**
+	 * Method to fill the last field for custom field integer
+	 *
+	 * @param   string  $last  The last value
+	 *
+	 * @Given I fill field last  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldLastWith($last)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$last, $last);
+	}
+
+	/**
+	 * Method to fill the step field for custom field integer
+	 *
+	 * @param   string  $step  The step value
+	 *
+	 * @Given I fill field step  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldStepWith($step)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$step, $step);
+	}
+
+	/**
+	 * Method to fill the preview field for custom field media
+	 *
+	 * @param   string  $preview  The preview
+	 *
+	 * @Given I select field preview :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldPreview($preview)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$preview['id'], $preview);
+	}
+
+	/**
+	 * Method to fill the home field for custom field media
+	 *
+	 * @param   string  $arg  The home
+	 *
+	 * @Given I check option home :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionHome($arg)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo("//select[@id='" . FieldsManagerPage_New::$home['id'] . "']");
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$home['id'], $arg);
+	}
+
+	/**
+	 * Method to fill the query field for custom field sql
+	 *
+	 * @param   string  $query  The query
+	 *
+	 * @Given I fill field query  with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldQueryWith($query)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->fillField(FieldsManagerPage_New::$query, $query);
+	}
+
+	/**
+	 * Method to select the schemes field for custom field url
+	 *
+	 * @param   string  $schemes  The schemes
+	 *
+	 * @Given I select field schemes :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldSchemes($schemes)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->click('#' . FieldsManagerPage_New::$schemes['id']);
+		$I->click("//div[@id='" . FieldsManagerPage_New::$schemes['id'] . "']/div/ul/li[contains(normalize-space(string(.)), '" . $schemes . "')]");
+	}
+
+	/**
+	 * Method to unselect the schemes field for custom field url
+	 *
+	 * @param   string  $schemes  The schemes
+	 *
+	 * @Given I unselect field schemes :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iUnselectFieldSchemes($schemes)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->click("//div[@id='" . FieldsManagerPage_New::$schemes['id'] .
+				"']/ul/li/span[contains(normalize-space(string(.)), '" . $schemes .
+				"')]/following-sibling::a[1]");
+	}
+
+	/**
+	 * Method to check the relative field for custom field url
+	 *
+	 * @param   string  $arg  The relative value
+	 *
+	 * @Given I check option relative :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionRelative($arg)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$general);
+
+		$I->scrollTo("//select[@id='" . FieldsManagerPage_New::$relative['id'] . "']");
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$relative['id'], $arg);
+	}
+
+	/**
+	 * Method to fill the placeholder or hint field for custom field url
+	 *
+	 * @param   string  $placeholder  The placeholder value
+	 *
+	 * @Given I fill field placeholder with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldPlaceholderWith($placeholder)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$options);
+
+		$I->fillField(FieldsManagerPage_New::$placeholder, $placeholder);
+	}
+
+	/**
+	 * Method to fill the render class field for custom field url
+	 *
+	 * @param   string  $renderclass  The render class value
+	 *
+	 * @Given I fill field renderclass with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldRenderclassWith($renderclass)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$options);
+		$I->fillField(FieldsManagerPage_New::$renderclass, $renderclass);
+	}
+
+	/**
+	 * Method to fill the edit class field for custom field url
+	 *
+	 * @param   string  $editclass  The edit class value
+	 *
+	 * @Given I fill field editclass with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldEditclassWith($editclass)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$options);
+		$I->fillField(FieldsManagerPage_New::$editclass, $editclass);
+	}
+
+	/**
+	 * Method to check the disabled field for custom field url
+	 *
+	 * @param   string  $disabled  The disables value
+	 *
+	 * @Given I check option disabled :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionDisabled($disabled)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$options);
+
+		$I->click("//fieldset[@id='" . FieldsManagerPage_New::$disabled['id'] . "']/label[contains(normalize-space(string(.)), '" . $disabled . "')]");
+	}
+
+	/**
+	 * Method to check the readonly field for custom field url
+	 *
+	 * @param   string  $readonly  The readonly value
+	 *
+	 * @Given I check option readonly :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionReadonly($readonly)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$options);
+		$I->click("//fieldset[@id='" . FieldsManagerPage_New::$readonly['id'] . "']/label[contains(normalize-space(string(.)), '" . $readonly . "')]");
+	}
+
+	/**
+	 * Method to check the shown field for custom field url
+	 *
+	 * @param   string  $showon  The showon value
+	 *
+	 * @Given I check option showon :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iCheckOptionShowon($showon)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$options);
+		$I->click("//fieldset[@id='" . FieldsManagerPage_New::$showon['id'] . "']/label[contains(normalize-space(string(.)), '" . $showon . "')]");
+	}
+
+	/**
+	 * Method to check the relative field for custom field url
+	 *
+	 * @param   string  $display  The display value
+	 *
+	 * @Given I select field automaticdisplay with :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSelectFieldAutomaticdisplayWith($display)
+	{
+		$I = $this;
+
+		$I->scrollTo(['id' => 'myTabTabs'], 10, -100);
+		$I->click(FieldsManagerPage_New::$options);
+
+		$I->selectOptionInChosenById(FieldsManagerPage_New::$display['id'], $display);
+	}
+
+	/**
+	 * Method to check if I see the system message with the in the
+	 * argument provided text
+	 *
+	 * @param   string  $message  The message text
+	 *
+	 * @Then I see message :arg1
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSeeMessage($message)
+	{
+		$I = $this;
+
+		$I->fieldsManagerPage_New->seeSystemMessage(FieldsManagerPage_New::$pageTitleText, $message);
+	}
+
+	/**
+	 * Method to check if I see the system message with the in the
+	 * argument provided text
+	 *
+	 * @param   string  $label         The label of the field
+	 * @param   string  $type          The type of the field
+	 * @param   string  $fieldgroup    The name of the fieldgroup
+	 * @param   string  $category      The name of the category
+	 * @param   string  $articletitle  The title of the article
+	 *
+	 * @Then I see the label :arg1 of type :arg2 in register :arg3 for category :arg4 if I create an article with title :arg5
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iSeeTheLabelOfTypeInRegisterForCategoryIfICreateAnArticleWithTitle($label, $type, $fieldgroup, $category, $articletitle)
+	{
+		$I = $this;
+
+		$I->amOnPage(ArticleManagerPage::$url);
+		$I->adminPage->clickToolbarButton('New');
+
+		$I->fillField(ArticleManagerPage::$title, $articletitle);
+		$I->wait(1);
+		$I->scrollTo(['css' => 'div.toggle-editor'], 20, 100);
+		$I->wait(1);
+		$I->click(ArticleManagerPage::$toggleEditor);
+		$I->fillField(ArticleManagerPage::$content, 'Test content for testing field');
+
+		$I->scrollTo(['css' => '#jform_featured'], 20, -100);
+		$I->click("//fieldset[@id='" . 'jform_featured' . "']/label[contains(normalize-space(string(.)), 'Yes')]");
+
+		$I->wait(1);
+		$I->adminPage->selectOptionInChosenById('jform_catid', $category);
+		$I->wait(1);
+		$I->scrollTo(['css' => '#item-form'], 20, -100);
+		$I->click($fieldgroup);
+
+		$I->see($label);
+
+		switch ($type)
+		{
+			case "Calendar":
+				break;
+			case "":
+				break;
+			default:
+		}
+
+		$I->adminPage->clickToolbarButton('Save');
+	}
+
+	/**
+	 * Method to fill test if I can fill the text field
+	 *
+	 * @param   string  $field  The field that should be filled
+	 * @param   string  $text   The that should be filled in
+	 *
+	 * @Then I can fill field :arg1 with the text :arg2
+	 *
+	 * @return  void
+	 */
+	public function iCanFillFieldWithTheText($field, $text)
+	{
+		$I = $this;
+
+		$I->fillField('#jform_params_' . str_replace(' ', '_', strtolower(trim($field))), $text);
+		$I->adminPage->clickToolbarButton('Save');
+	}
+
+	/**
+	 * Method to check if I can see the textfield int the frontend
+	 *
+	 * @param   string  $text          The in the text field that should be displayed
+	 * @param   string  $label         The label that should be displayed
+	 * @param   string  $articletitle  The title of the article that should be show the field
+	 *
+	 * @Then I can see the field with the text :arg1 and the label :arg2 in frontend in the articel with title :arg3
+	 *
+	 * @return  void
+	 */
+	public function iCanSeeTheFieldWithTheTextAndTheLabelInFrontendInTheArticelWithTitle($text, $label, $articletitle)
+	{
+		$I = $this;
+
+		$I->amOnPage(FrontPage::$url);
+		$I->click($articletitle);
+		$I->see($text);
+		$I->see($label);
+	}
+
+	/**
+	 * Method to sae and close custum field
+	 *
+	 * @Given I save and close custom field
+	 *
+	 * @return  void
+	 */
+	public function iSaveAndCloseCustomField()
+	{
+		$I = $this;
+
+		$I->adminPage->clickToolbarButton('Save & Close');
+		$I->comment('READY');
+	}
+
+	/**
+	 * Method to fill all fields for a custom field
+	 *
+	 * @param   string  $field_params  The field_params
+	 *
+	 * @When I fill fields for creating Field
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function iFillFieldsForCreatingField($field_params)
+	{
+		$I = $this;
+
+		$I->adminPage->clickToolbarButton('New');
+
+		$totalRows = count($field_params->getRows());
+		$lastIndex = ($totalRows - 1);
+
+		// Iterate over all rows
+		foreach ($field_params->getRows() as $index => $row)
+		{
+			if ($index !== 0)
+			{
+				// Standard
+				if (isset($row[0]) and ! empty($row[0]))
+				{
+					$this->iFillFieldTitleWith($row[0]);
+				}
+
+				if (isset($row[1]) and ! empty($row[1]))
+				{
+					$this->iSelectFieldType($row[1]);
+				}
+
+				if (isset($row[2]) and ! empty($row[2]))
+				{
+					$this->iFillFieldLabelWith($row[2]);
+				}
+
+				if (isset($row[3]) and ! empty($row[3]))
+				{
+					$this->iFillFieldDescriptionWith($row[3]);
+				}
+
+				if (isset($row[4]) and ! empty($row[4]))
+				{
+					$this->iCheckOptionRequired($row[4]);
+				}
+
+				if (isset($row[5]) and ! empty($row[5]))
+				{
+					$this->iFillFieldDefault_valueWith($row[5]);
+				}
+
+				if (isset($row[6]) and ! empty($row[6]))
+				{
+					$this->iSelectFieldState($row[6]);
+				}
+
+				if (isset($row[7]) and ! empty($row[7]))
+				{
+
+					$this->iSelectFieldGroup($row[7]);
+				}
+
+				// I can't use iSelectFieldCats
+				if (isset($row[8]) and ! empty($row[8]))
+				{
+					$I->click('#' . FieldsManagerPage_New::$cat_ids['id']);
+					$I->click("//div[@id='" . FieldsManagerPage_New::$cat_ids['id'] .
+							"']/div/ul/li[contains(normalize-space(string(.)), '" . $row[8] .
+							"')]");
+					$I->click("//div[@id='" . FieldsManagerPage_New::$cat_ids['id'] .
+							"']/ul/li/span[contains(normalize-space(string(.)), 'All')]/following-sibling::a[1]");
+				}
+
+				if (isset($row[9]) and ! empty($row[9]))
+				{
+					$this->iSelectFieldAccess($row[9]);
+				}
+
+				if (isset($row[10]) and ! empty($row[10]))
+				{
+					$this->iSelectFieldLanguage($row[10]);
+				}
+
+				if (isset($row[11]) and ! empty($row[11]))
+				{
+					$this->iFillFieldNoteWith($row[11]);
+				}
+
+				// CALENDARFIELD
+				if ($row[1] == "Calendar (calendar)" and isset($row[12]) and ! empty($row[12]))
+				{
+					$this->iCheckOptionShowtime($row[12]);
+				}
+
+				// CHECKBOX LIST and RADIO
+				if (($row[1] == "Checkboxes (checkboxes)" or $row[1] == "List (list)" or $row[1] == "Radio (radio)") and isset($row[13]) and ! empty($row[13]))
+				{
+					$arr = explode(',', $row[13]);
+					$I->scrollTo(['css' => '.adminlist'], 20, 50);
+
+					$max = sizeof($arr);
+
+					$I->click('.group-add');
+
+					foreach ($arr as $index => $item)
+					{
+						$css = $index + 1;
+						$I->fillField('#jform_fieldparams_options_options' . $css . '_name', $item);
+						$I->fillField('#jform_fieldparams_options_options' . $css . '_value', $item);
+
+						if ($max - 1 !== $index)
+						{
+							$I->click('.group-add');
+						}
+					}
+				}
+
+				// Editor
+				if ($row[1] == "Editor (editor)" and isset($row[14]) and ! empty($row[14]))
+				{
+					$this->iCheckOptionButtons($row[14]);
+				}
+
+				if ($row[1] == "Editor (editor)" and isset($row[15]) and ! empty($row[15]))
+				{
+					$this->iFillFieldHideWith($row[15]);
+				}
+
+				if ($row[1] == "Editor (editor)" and isset($row[16]) and ! empty($row[16]))
+				{
+					$I->iFillFieldWidthWith($row[16]);
+				}
+
+				if ($row[1] == "Editor (editor)" and isset($row[17]) and ! empty($row[17]))
+				{
+					$this->iFillFieldHeightWith($row[17]);
+				}
+
+				// Textarea
+				if (($row[1] == "Text Area (textarea)") and isset($row[18]) and ! empty($row[18]))
+				{
+					$I->fillField(FieldsManagerPage_New::$rows, $row[18]);
+				}
+
+				if (($row[1] == "Text Area (textarea)") and isset($row[19]) and ! empty($row[19]))
+				{
+					$I->fillField(FieldsManagerPage_New::$cols, $row[19]);
+				}
+
+				// Gallery
+				if (($row[1] == "Gallery (gallery") and isset($row[20]) and ! empty($row[20]))
+				{
+					$this->iFillFieldThumbnailWidthWith($row[20]);
+				}
+
+				if (($row[1] == "Gallery (gallery") and isset($row[21]) and ! empty($row[21]))
+				{
+					$this->iFillFieldMaxWidthWith($row[21]);
+				}
+
+				if (($row[1] == "Gallery (gallery") and isset($row[22]) and ! empty($row[22]))
+				{
+					$this->iFillFieldMaxHeightWith($row[22]);
+				}
+
+				if (($row[1] == "Gallery (gallery") and isset($row[23]) and ! empty($row[23]))
+				{
+					$this->iCheckOptionRecursive($row[23]);
+				}
+
+				// Gallery, Image, Integer, List, User, Usergrouplist
+				if (($row[1] == "Gallery (gallery)"
+					or $row[1] == "Imagelist (imagelist)"
+					or $row[1] == "Integer (integer)"
+					or $row[1] == "List (list)"
+					or $row[1] == "SQL sql"
+					or $row[1] == "User (user)"
+					or $row[1] == "User Groups (usergrouplist)")
+					and isset($row[24]) and ! empty($row[24]))
+				{
+					$this->iCheckOptionMultiple($row[24]);
+				}
+
+				// Gallery and Media
+				if (($row[1] == "Gallery (gallery)" or $row[1] == "Media (media)") and isset($row[25]) and ! empty($row[25]))
+				{
+					$this->iFillFieldDirectoryWith($row[25]);
+				}
+
+				// Image
+				if ((($row[1] == "Imagelist (imagelist)") || ($row[1] == "Media (media)")) and isset($row[26]) and ! empty($row[26]))
+				{
+					$this->iFillFieldImage_classWith($row[26]);
+				}
+
+				// Integer
+				if (($row[1] == "Integer (integer)") and isset($row[27]) and ! empty($row[27]))
+				{
+					$this->iFillFieldFirstWith($row[27]);
+				}
+
+				if (($row[1] == "Integer (integer)") and isset($row[28]) and ! empty($row[28]))
+				{
+					$this->iFillFieldLastWith($row[28]);
+				}
+
+				if (($row[1] == "Integer (integer)") and isset($row[29]) and ! empty($row[29]))
+				{
+					$this->iFillFieldStepWith($row[29]);
+				}
+
+				// Media
+				if (($row[1] == "Media (media)") and isset($row[30]) and ! empty($row[30]))
+				{
+					$this->iSelectFieldPreview($row[30]);
+				}
+
+				if (($row[1] == "Media (media)") and isset($row[31]) and ! empty($row[31]))
+				{
+					$this->iCheckOptionHome($row[31]);
+				}
+
+				// SQL
+				if (($row[1] == "SQL (sql)") and isset($row[32]) and ! empty($row[32]))
+				{
+					$this->iFillFieldQueryWith($row[32]);
+				}
+
+				// URL
+				if (($row[1] == "Url (url)") and isset($row[33]) and ! empty($row[33]))
+				{
+					$this->iSelectFieldSchemes($row[33]);
+				}
+
+				if (($row[1] == "Url (url)") and isset($row[34]) and ! empty($row[34]))
+				{
+					$this->iCheckOptionRelative($row[34]);
+				}
+
+				// TEXT
+				if (($row[1] == "Text (text)") and isset($row[36]) and ! empty($row[36]))
+				{
+					$this->iSelectFieldFilter($row[36]);
+				}
+
+				// Options Register
+				if (isset($row[35]) and ! empty($row[35]))
+				{
+					$this->iFillFieldPlaceholderWith($row[35]);
+				}
+
+				if (isset($row[38]) and ! empty($row[38]))
+				{
+					$this->iFillFieldRenderclassWith($row[38]);
+				}
+
+				if (isset($row[39]) and ! empty($row[39]))
+				{
+					$this->iFillFieldEditclassWith($row[39]);
+				}
+
+				if (isset($row[40]) and ! empty($row[40]))
+				{
+					$this->iCheckOptionDisabled($row[40]);
+				}
+
+				if (isset($row[41]) and ! empty($row[41]))
+				{
+					$this->iCheckOptionReadonly($row[41]);
+				}
+
+				if (isset($row[42]) and ! empty($row[42]))
+				{
+					$this->iCheckOptionShowon($row[42]);
+				}
+
+				if (isset($row[43]) and ! empty($row[43]))
+				{
+					$this->iSelectFieldAutomaticdisplayWith($row[43]);
+				}
+
+				// Last Field should use Save & Close
+				if ($index == $lastIndex)
+				{
+					$I->adminPage->clickToolbarButton('Save & Close');
+					$I->comment('READY');
+				}
+				else
+				{
+					$I->adminPage->clickToolbarButton('Save & New');
+				}
+			}
+		}
+	}
+}

--- a/tests/codeception/acceptance/fields.feature
+++ b/tests/codeception/acceptance/fields.feature
@@ -1,0 +1,474 @@
+Feature: CustomFields
+  In order to manage Custom Fields in the web
+  I need to create Custom Fields with all options
+
+  Background:
+    When I Login into Joomla administrator
+    And I see the administrator dashboard
+
+  ###
+  ### Create a field group for using in the custom field creation
+  ###
+  Scenario: Create a Field Group
+    Given There is a add field group link
+    And I click toolbar button "New"
+    And I fill field title with "NewFieldGroup"
+    And I click toolbar button "Save"
+
+  ###
+  ### You can create many field groups if you need
+  ###
+  Scenario: Create many Field Groups
+    Given There is a add field group link
+    When I fill mandatory fields for creating Field Group
+      | Title           |
+      | NewFieldGroup_1 |
+      | NewFieldGroup_2 |
+
+  ###
+  ### Create a category for using in the custom field creation
+  ###
+  Scenario: Create new categories
+    Given There is an article category link
+    When I fill mandatory fields for creating Category
+      | Title                     |
+      | Category_FieldGroupTest_1 |
+      | Category_FieldGroupTest_2 |
+
+  ###
+  ### CALENDAR with all options
+  ###
+  Scenario: Create Calendar field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewCalendarField"
+    ##Type
+    And I select field type "Calendar (calendar)"
+    ##Label
+    And I fill field label  with "Label for NewCalendarField"
+    ##Description
+    And I fill field description  with "Decription for NewCalendarField"
+    ##Required
+    And I check option required "Yes"
+    And I check option required "No"
+    ##Default #invalide default breaks the article view
+    And I fill field default_value  with "2017-01-01"
+    ##State
+    And I select field state "Trashed"
+    And I select field state "Published"
+    And I select field state "Unpublished"
+    And I select field state "Archived"
+    ##FieldGroup
+    And I select field group "NewFieldGroup"
+    ##Categorie
+    And I select field cat "Category_FieldGroupTest_2"
+    And I unselect field cat "All"
+    ##Access
+    And I select field access "Public"
+    And I select field access "Registered"
+    And I select field access "Special"
+    And I select field access "Super Users"
+    ##Language
+    And I select field language "English (en-GB)"
+    ##Note
+    And I fill field note with "My personal note"
+    And I click toolbar button "Save"
+    ##Placeholder
+    And I fill field placeholder with "placeholder"
+    ##Renderclass
+    And I fill field renderclass with "renderclass"
+    ##Editclass
+    And I fill field editclass with "editclass"
+    ##Disabled
+    And I check option disabled "Yes"
+    And I check option disabled "No"
+    ##Readonly
+    And I check option readonly "Yes"
+    And I check option readonly "No"
+    ##Showon
+    And I check option showon "Site"
+    And I check option showon "Administrator"
+    And I check option showon "Both"
+    ##Automaticdisplay
+    And I select field automaticdisplay with "After Title"
+    And I select field automaticdisplay with "Before Display"
+    And I select field automaticdisplay with "After Display"
+    And I select field automaticdisplay with "No"
+    ##Extras for calendar field
+    ##Showtime
+    And I check option showtime "Yes"
+    And I check option showtime "No"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### CHECKBOX only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Checkbox field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewCheckboxField"
+    ##Type
+    And I select field type "Checkboxes (checkboxes)"
+    ##...
+    ##Extras for checkbox field
+    And I fill field options
+      | Name   | Value   |
+      | Name_1 | Value_1 |
+      | Name_2 | Value_2 |
+      | Name_3 | Value_3 |
+      | Name_4 | Value_4 |
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### COLOR only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Colour field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewColourField"
+    ##Type
+    And I select field type "Colour (color)"
+    ##...
+    ## No extras for color field
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### EDITOR only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Editor field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewEditorField"
+    ##Type
+    And I select field type "Editor (editor)"
+    ## Extras for editor field
+    ##Buttons
+    And I check option buttons "Yes"
+    And I check option buttons "No"
+    And I check option buttons "Use From Plugin"
+    ##Hide
+    And I fill field hide  with "pagebreak,readmore"
+    ##Width
+    And I fill field width  with "50%"
+    ##Height
+    And I fill field height  with "100px"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### GALLERY only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Gallery field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewGalleryField"
+    ##Type
+    And I select field type "Gallery (gallery)"
+    ## ...
+    ## Extras for gallery field
+    ##ThumbnailWidth
+    And I fill field ThumbnailWidth  with "50"
+    ##MaxWidth
+    And I fill field MaxWidth  with "200"
+    ##MaxHeight
+    And I fill field MaxHeight  with "200"
+    ##Recursiv
+    And I check option recursive "Yes"
+    And I check option recursive "No"
+    And I check option recursive "Use From Plugin"
+    ##Multiple
+    And I check option multiple "Yes"
+    And I check option multiple "No"
+    And I check option multiple "Use From Plugin"
+    ##Directory
+    And I fill field directory  with "images/sampledata"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### INTEGER only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Integer field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewIntegerField"
+    ##Type
+    And I select field type "Integer (integer)"
+    ## ...
+    ## Extras for integer field
+    ##Multiple
+    And I check option multiple "Yes"
+    And I check option multiple "No"
+    And I check option multiple "Use From Plugin"
+    ##First
+    And I fill field first  with "10"
+    ##Last
+    And I fill field last  with "50"
+    ##Step
+    And I fill field step  with "2"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### LIST only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create List field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewListField"
+    ##Type
+    And I select field type "List (list)"
+    ## ...
+    ## Extras for list field
+    ##Multiple
+    And I check option multiple "Yes"
+    And I check option multiple "No"
+    And I check option multiple "Use From Plugin"
+    And I fill field options
+      | Name   | Value   |
+      | Name_1 | Value_1 |
+      | Name_2 | Value_2 |
+      | Name_3 | Value_3 |
+      | Name_4 | Value_4 |
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### LIST OFIMAGES only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create List of Images field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewListofImagesField"
+    ##Type
+    And I select field type "List of Images (imagelist)"
+    ## ...
+    ## Extras for images field
+    ##Directory
+    And I select field directory  with "sampledata"
+    ##Multiple
+    And I check option multiple "Yes"
+    And I check option multiple "No"
+    And I check option multiple "Use From Plugin"
+    ##Image_class
+    And I fill field image_class  with "my_imageclass_for_testing_imagefield"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### MEDIA only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Media field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewMediaField"
+    ##Type
+    And I select field type "Media (media)"
+    ## ...
+    ## Extras for media field
+    ##Directory
+    And I fill field directory  with "images/sampledata"
+    ##Preview
+    And I select field preview "Tooltip"
+    And I select field preview "Inline"
+    And I select field preview "No"
+    ##Home
+    And I check option home "No"
+    And I check option home "Yes"
+    And I check option home "Use From Plugin"
+    ##Image_class
+    And I fill field image_class  with "my_imageclass_for_testing_imagefield"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### RADIO only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Radio field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewRadioField"
+    ##Type
+    And I select field type "Radio (radio)"
+    ## ...
+    ## Extras for radio field
+    And I fill field options
+      | Name   | Value   |
+      | Name_1 | Value_1 |
+      | Name_2 | Value_2 |
+      | Name_3 | Value_3 |
+      | Name_4 | Value_4 |
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### SQL only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create SQL field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewSQLField"
+    ##Type
+    And I select field type "SQL (sql)"
+    ## ...
+    ## Extras for sql field
+    ##Query
+    And I fill field query  with "select id as value, title as text from #__modules"
+    ##Multiple
+    And I check option multiple "Yes"
+    And I check option multiple "No"
+    And I check option multiple "Use From Plugin"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### TEXT only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Text field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewTextField"
+    ##Type
+    And I select field type "Text (text)"
+    ## ...
+    ## Extras for text field
+    ## Filter
+    And I select field filter "Use From Plugin"
+    And I select field filter "Raw"
+    And I select field filter "No"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### TESTAREA only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Textarea field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewTextareaField"
+    ##Type
+    And I select field type "Text Area (textarea)"
+    ## ...
+    ## Extras for textarea field
+    ##Rows
+    And I fill field rows  with "20"
+    ##Cols
+    And I fill field cols  with "20"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### URL only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Url field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewUrlField"
+    ##Type
+    And I select field type "Url (url)"
+    ## ...
+    ## Extras for url field
+    ##Schemes
+    And I select field schemes "FILE"
+    And I select field schemes "MAILTO"
+    And I select field schemes "HTTP"
+    And I select field schemes "FTP"
+    And I select field schemes "FTPS"
+    And I select field schemes "URL"
+    And I unselect field schemes "MAILTO"
+    ##Relative
+    And I check option relative "Yes"
+    And I check option relative "No"
+    And I check option relative "Use From Plugin"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### USER only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create User field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewUserField"
+    ##Type
+    And I select field type "User (user)"
+    ## ...
+    ## No extras for user field
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### USERGROUPS only with required and special checkbox options,
+  ###          see Calendar field for all options
+  ###
+  Scenario: Create Usergroup field
+    Given There is a add field link
+    And I click toolbar button "New"
+    ##Title
+    And I fill field title with "NewListofUsergroupField"
+    ##Type
+    And I select field type "User Groups (usergrouplist)"
+    ## ...
+    ## Extras for usergroup field
+    ##Multiple
+    And I check option multiple "Yes"
+    And I check option multiple "No"
+    And I check option multiple "Use From Plugin"
+    ##Save the field
+    And I save and close custom field
+
+  ###
+  ### Create many fields
+  ###
+  Scenario: Create many Fields
+    Given There is a add field link
+    When I fill fields for creating Field
+      | Title0               | Type1                       | Label2               | Description3               | Required4 | Default5                                | State6    | FieldGroup7   | Categorie8                | Access9 | Language10      | Note11                              | ShowTime12 | Options13               | Buttons14 | Hide15             | Width16 | Height17 | Rows18 | Cols19 | Thumbnailwidth20 | Maxwidth21 | Maxheight22 | Recursive23 | Multiple24 | Directory25       | Image_class26 | First27 | Last28 | Step29 | Preview30 | Home31 | Query32                                           | Schemes33 | Relative34 | Placeholder35 | Filter36 | leer37 | RenderClass38 | EditClass39 | Disabled40 | Readonly41 | Showon42 | AutomaticDisplay43 |
+      | CalendarField_1      | Calendar (calendar)         | CalendarLabel_1      | CalendarDescription_1      | Yes       | 2017-01-01                              | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Calendarfield Note      | Yes        |                         |           |                    |         |          |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | CheckboxField_1      | Checkboxes (checkboxes)     | CheckboxLabel_1      | CheckboxDescription_1      | Yes       | Option2                                 | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Checkboxfield Note      |            | Option1,Option2,Option3 |           |                    |         |          |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | ColorField_1         | Colour (color)              | ColorLabel_1         | ColorDescription_1         | Yes       | #ff0000                                 | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Colorfield Note         |            |                         |           |                    |         |          |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | EditorField_1        | Editor (editor)             | EditorLabel_1        | EditorDescription_1        | Yes       | My default Text in the editor_1 field   | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Editorfield Note        |            |                         | Yes       | pagebreak,readmore | 50%     | 100px    |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | GalleryField_1       | Gallery (gallery)           | GalleryLabel_1       | GalleryDescription_1       | Yes       | parks                                   | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Galleryfield Note       |            |                         |           |                    |         |          |        |        | 50               | 200        | 200         | Yes         | Yes        | images/sampledata |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | IntegerField_1       | Integer (integer)           | IntegerLabel_1       | IntegerDescription_1       | Yes       | 15                                      | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Integerfield Note       |            |                         |           |                    |         |          |        |        |                  |            |             |             | Yes        |                   |               | 10      | 20     | 1      |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | list_1               | List (list)                 | ListLabel_1          | ListDescription_1          | Yes       | Option2                                 | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Listfield Note          |            | Option1,Option2,Option3 |           |                    |         |          |        |        |                  |            |             |             | Yes        |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | Imagelist_1          | List of Images (imagelist)  | ImagelistLabel_1     | ImagelistDescription_1     | Yes       |                                         | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Imagelistfield Note     |            |                         |           |                    |         |          |        |        |                  |            |             |             | Yes        | images/sampledata | imageclass    |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | MediaField_1         | Media (media)               | MediaLabel_1         | MediaDescription_1         | Yes       | images/joomla_black.png                 | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Mediafield Note         |            |                         |           |                    |         |          |        |        |                  |            |             |             |            | images/sampledata | imageclass    |         |        |        | Inline    | Yes    |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | RadioField_1         | Radio (radio)               | RadioLabel_1         | RadioDescription_1         | Yes       | Option2                                 | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Radiofield Note         |            | Option1,Option2,Option3 |           |                    |         |          |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | SQLField_1           | SQL (sql)                   | SQLLabel_1           | SQLDescription_1           | Yes       | 2                                       | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal SQLfield Note           |            |                         |           |                    |         |          |        |        |                  |            |             |             | Yes        |                   |               |         |        |        |           |        | select id as value, title as text from #__modules |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | TextField_1          | Text (text)                 | TextLabel_1          | TextDescription_1          | Yes       | My default Text in the text_1 field     | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Textfield Note          |            |                         |           |                    |         |          |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   | Raw      |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | TextareaField_1      | Text Area (textarea)        | TextareaLabel_1      | TextareaDescription_1      | Yes       | My default Text in the textarea_1 field | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Textareafield Note      |            |                         |           |                    |         |          | 20     | 40     |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | URLField_1           | Url (url)                   | URLLabel_1           | URLDescription_1           | Yes       | www.example.org                         | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal URLfield Note           |            |                         |           |                    |         |          |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   | HTTP      | Yes        | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | UserField_1          | User (user)                 | UserLabel_1          | UserDescription_1          | Yes       |                                         | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Userfield Note          |            |                         |           |                    |         |          |        |        |                  |            |             |             |            |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |
+      | UsergrouplistField_1 | User Groups (usergrouplist) | UsergrouplistLabel_1 | UsergrouplistDescription_1 | Yes       | 2                                       | Published | NewFieldGroup | Category_FieldGroupTest_1 | Public  | English (en-GB) | My personal Usergrouplistfield Note |            |                         |           |                    |         |          |        |        |                  |            |             |             | Yes        |                   |               |         |        |        |           |        |                                                   |           |            | Placeholder   |          |        | renderclass   | editclassc  | No         | No         | Both     | After Title        |


### PR DESCRIPTION
### Summary of Changes

I created tests for testing custom fields I would be happy if some of you would give me a feedback.

This tests are working with the current joomla-cms version (Joomla! 3.7.0-beta2). I changed the url in my acceptance.suite.yml to a installation of the current joomla-cms staging branch. Older version  are not possible, because custom fields have many changes in the last weeks.

Please have a look to the feature file. You can create one field or you can create many fields in one step.


Next you see as an example creating the  calendar field with all possible options. You do not need to fill all options. You only need to fill the mandatory options.

```
  ###
  ### CALENDAR with all options
  ###
  Scenario: Create Calendar field
    Given There is a add field link
    And I click toolbar button "New"
    ##Title
    And I fill field title with "NewCalendarField"
    ##Type
    And I select field type "Calendar (calendar)"
    ##Label
    And I fill field label  with "Label for NewCalendarField"
    ##Description
    And I fill field description  with "Decription for NewCalendarField"
    ##Required
    And I check option required "Yes"
    And I check option required "No"
    ##Default #invalide default breaks the article view
    And I fill field default_value  with "2017-01-01"
    ##State
    And I select field state "Trashed"
    And I select field state "Published"
    And I select field state "Unpublished"
    And I select field state "Archived"
    ##FieldGroup
    And I select field group "NewFieldGroup"
    ##Categorie
    And I select field cat "Category_FieldGroupTest_2"
    And I unselect field cat "All"
    ##Access
    And I select field access "Public"
    And I select field access "Registered"
    And I select field access "Special"
    And I select field access "Super Users"
    ##Language
    And I select field language "English (en-GB)"
    ##Note
    And I fill field note with "My personal note"
    And I click toolbar button "Save"
    ##Placeholder
    And I fill field placeholder with "placeholder"
    ##Renderclass
    And I fill field renderclass with "renderclass"
    ##Editclass
    And I fill field editclass with "editclass"
    ##Disabled
    And I check option disabled "Yes"
    And I check option disabled "No"
    ##Readonly
    And I check option readonly "Yes"
    And I check option readonly "No"
    ##Showon
    And I check option showon "Site"
    And I check option showon "Administrator"
    And I check option showon "Both"
    ##Automaticdisplay
    And I select field automaticdisplay with "After Title"
    And I select field automaticdisplay with "Before Display"
    And I select field automaticdisplay with "After Display"
    And I select field automaticdisplay with "No"
    ##Extras for calendar field
    ##Showtime
    And I check option showtime "Yes"
    And I check option showtime "No"
    ##Save the field
    And I save and close custom field
```

Please see the [feature fil](https://github.com/joomla-projects/gsoc16_browser-automated-tests/pull/125/files#diff-1e09bf32ebe454b98a94d5b0ad7b0d35R455)e for an example to create many fields in one step. You can set all options for a field into one line. But you do not need to fill all options. You can leave all optional option empty. 


@Niels Braczek
Is this similar how you want to build your library?